### PR TITLE
Align `Matching` to `WeightEstimator` interface

### DIFF
--- a/causallib/estimation/matching.py
+++ b/causallib/estimation/matching.py
@@ -22,6 +22,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
 from sklearn.base import clone as sk_clone
 from .base_estimator import IndividualOutcomeEstimator
+from .base_weight import WeightEstimator
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial import distance
 
@@ -36,7 +37,7 @@ def majority_rule(x):
     return Counter(x).most_common(1)[0][0]
 
 
-class Matching(IndividualOutcomeEstimator):
+class Matching(IndividualOutcomeEstimator, WeightEstimator):
 
     def __init__(
         self,
@@ -332,7 +333,6 @@ class Matching(IndividualOutcomeEstimator):
 
         return self._get_match_df(successful_matches_only=successful_matches_only)
 
-
     def matches_to_weights(self, match_df=None):
         """Calculate weights based on a given set of matches.
 
@@ -362,6 +362,42 @@ class Matching(IndividualOutcomeEstimator):
             for s, t in match_permutations],).T
 
         return weights_df
+
+    def compute_weights(self, X, a, treatment_values=None, use_stabilized=None, **kwargs):
+        """Calculate weights based on a given set of matches.
+
+        Only applicable for `matching_mode` "control_to_treatment"
+        or "treatment_to_control".
+
+        Args:
+            X (pd.DataFrame): DataFrame of shape (n,m) containing m covariates
+                for n samples.
+            a (pd.Series): Series of shape (n,) containing discrete treatment
+                values for the n samples.
+            treatment_values: IGNORED.
+            use_stabilized: IGNORED.
+            **kwargs:
+
+        Returns:
+            pd.Series: a Series of shape (n,) with a weight per sample.
+
+        Raises:
+            ValueError if `Matching().matching_mode == 'both'`.
+        """
+        self.match(X, a, successful_matches_only=False)
+
+        w = self.matches_to_weights()
+        if self.matching_mode == "both":
+            raise ValueError(
+                f"Matching mode {self.matching_mode} is not supported for weight calculation."
+                f"Please use 'control_to_treatment' or 'treatment_to_control'."
+            )
+        w = w[self.matching_mode]
+        return w
+
+    def compute_weight_matrix(self, X, a, use_stabilized=None, **kwargs):
+        raise NotImplementedError("Weight matrix is not supported for a Matching estimator.")
+        # TODO: is that so?
 
     def get_covariates_of_matches(self, s, t, covariates):
         """

--- a/causallib/evaluation/evaluator.py
+++ b/causallib/evaluation/evaluator.py
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import StratifiedKFold
 
-from .predictions import WeightEvaluatorScores
+from .predictions import PropensityEvaluatorScores
 from .predictor import predict_cv
 from .results import EvaluationResults
 from .scoring import score_cv
@@ -257,7 +257,7 @@ def evaluate_bootstrap(
     
     results.remove_spurious_cv()
     if results.evaluated_metrics is not None:
-        if isinstance(results.evaluated_metrics, WeightEvaluatorScores):
+        if isinstance(results.evaluated_metrics, PropensityEvaluatorScores):
             results.evaluated_metrics.covariate_balance.index.rename("sample", "fold", inplace=True)
             results.evaluated_metrics.prediction_scores.index.rename("sample", "fold", inplace=True)
         else:

--- a/causallib/evaluation/predictions.py
+++ b/causallib/evaluation/predictions.py
@@ -13,8 +13,8 @@ from .metrics import evaluate_metrics
 from ..metrics.weight_metrics import calculate_covariate_balance
 
 
-WeightEvaluatorScores = namedtuple(
-    "WeightEvaluatorScores", ["prediction_scores", "covariate_balance"]
+PropensityEvaluatorScores = namedtuple(
+    "PropensityEvaluatorScores", ["prediction_scores", "covariate_balance"]
 )
 
 
@@ -44,7 +44,7 @@ class WeightPredictions:
         covariate_balance = calculate_covariate_balance(
             X, a_true, self.weight_by_treatment_assignment
         )
-        # results = WeightEvaluatorScores(None, covariate_balance)
+        # results = PropensityEvaluatorScores(None, covariate_balance)
         return covariate_balance
 
 
@@ -99,7 +99,7 @@ class PropensityPredictions(WeightPredictions):
             X, a_true, self.weight_by_treatment_assignment
         )
 
-        results = WeightEvaluatorScores(evaluated_metrics_df, covariate_balance)
+        results = PropensityEvaluatorScores(evaluated_metrics_df, covariate_balance)
         # TODO: rename to PropensityEvaluatorScorers ?
         return results
 

--- a/causallib/evaluation/predictor.py
+++ b/causallib/evaluation/predictor.py
@@ -185,15 +185,10 @@ class WeightPredictor(BasePredictor):
         weight_for_being_treated = self.estimator.compute_weights(
             X, a, treatment_values=a.max(), use_stabilized=False
         )
-        treatment_assignment_pred = self.estimator.learner.predict(
-            X
-        )  # TODO: maybe add predict_label to interface instead
-        treatment_assignment_pred = pd.Series(treatment_assignment_pred, index=X.index)
 
         prediction = WeightPredictions(
             weight_by_treatment_assignment,
             weight_for_being_treated,
-            treatment_assignment_pred,
         )
         return prediction
 
@@ -227,13 +222,18 @@ class PropensityPredictor(WeightPredictor):
         propensity_matrix = self.estimator.compute_propensity_matrix(X)
         propensity_by_treatment_assignment = robust_lookup(propensity_matrix, a)
 
+        treatment_assignment_pred = self.estimator.learner.predict(
+            X
+        )  # TODO: maybe add predict_label to interface instead
+        treatment_assignment_pred = pd.Series(treatment_assignment_pred, index=X.index)
+
         weight_prediction = super().predict(X, a)
         # Do not force stabilize=False as in WeightEvaluator:
         weight_by_treatment_assignment = self.estimator.compute_weights(X, a)
         prediction = PropensityPredictions(
             weight_by_treatment_assignment,
             weight_prediction.weight_for_being_treated,
-            weight_prediction.treatment_assignment_pred,
+            treatment_assignment_pred,
             propensity,
             propensity_by_treatment_assignment,
         )

--- a/causallib/evaluation/results.py
+++ b/causallib/evaluation/results.py
@@ -13,7 +13,7 @@ import pandas as pd
 from ..estimation.base_estimator import IndividualOutcomeEstimator
 from ..estimation.base_weight import PropensityEstimator, WeightEstimator
 
-from .predictions import WeightEvaluatorScores, SingleFoldPrediction
+from .predictions import PropensityEvaluatorScores, SingleFoldPrediction
 from .plots import mixins, data_extractors
 
 
@@ -22,7 +22,7 @@ class EvaluationResults(abc.ABC):
     """Data structure to hold evaluation results including cross-validation.
 
     Attrs:
-        evaluated_metrics (Union[pd.DataFrame, WeightEvaluatorScores, None]):
+        evaluated_metrics (Union[pd.DataFrame, PropensityEvaluatorScores, None]):
         models (dict[str, Union[list[WeightEstimator], list[IndividualOutcomeEstimator]):
             Models trained during evaluation. May be dict or list or a model
             directly.
@@ -36,7 +36,7 @@ class EvaluationResults(abc.ABC):
         y (pd.Series): outcome data
     """
 
-    evaluated_metrics: Union[pd.DataFrame, WeightEvaluatorScores]
+    evaluated_metrics: Union[pd.DataFrame, PropensityEvaluatorScores]
     models: Union[
         List[WeightEstimator],
         List[IndividualOutcomeEstimator],
@@ -58,7 +58,7 @@ class EvaluationResults(abc.ABC):
 
     @staticmethod
     def make(
-        evaluated_metrics: Union[pd.DataFrame, WeightEvaluatorScores],
+        evaluated_metrics: Union[pd.DataFrame, PropensityEvaluatorScores],
         models: Union[
             List[WeightEstimator],
             List[IndividualOutcomeEstimator],
@@ -149,7 +149,7 @@ class EvaluationResults(abc.ABC):
         self.models = self.models[0]
         if isinstance(self.evaluated_metrics, pd.DataFrame):
             self.evaluated_metrics.reset_index(level=["phase", "fold"], drop=True, inplace=True)
-        elif isinstance(self.evaluated_metrics, WeightEvaluatorScores):
+        elif isinstance(self.evaluated_metrics, PropensityEvaluatorScores):
             for metric in self.evaluated_metrics:
                 metric.reset_index(level=["phase", "fold"], drop=True, inplace=True)
 

--- a/causallib/tests/test_matching.py
+++ b/causallib/tests/test_matching.py
@@ -435,6 +435,30 @@ class TestMatching(unittest.TestCase):
             0,
         )
 
+    def test_compute_weights(self):
+        X, a, y = self.data_serial_unbalanced_x
+
+        matching_mode = "control_to_treatment"
+        self.matching.matching_mode = matching_mode
+        self.matching.with_replacement = False
+        self.matching.fit(X, a, y)
+
+        w = self.matching.compute_weights(X, a)
+
+        with self.subTest("Compare to `matches_to_weights` base function"):
+            full_weights = self.matching.matches_to_weights()
+            pd.testing.assert_series_equal(w, full_weights[matching_mode])
+
+        with self.subTest("Fails for `matching_mode='both'`"):
+            with self.assertRaises(ValueError):
+                self.matching.matching_mode = "both"
+                self.matching.compute_weights(X, a)
+
+    def test_compute_weight_matrix(self):
+        X, a, y = self.data_serial_unbalanced_x
+        with self.assertRaises(NotImplementedError):
+            self.matching.compute_weight_matrix(X, a)
+
     def test_exception_for_no_replacement_and_n_neighbors_gt_1(self):
         X, a, y = self.data_serial_x
         self.matching.n_neighbors = 2

--- a/causallib/tests/test_survival.py
+++ b/causallib/tests/test_survival.py
@@ -7,6 +7,7 @@ from sklearn.pipeline import Pipeline
 from causallib.datasets.data_loader import load_nhefs_survival
 from causallib.survival.survival_utils import get_person_time_df, safe_join
 from causallib.estimation.ipw import IPW
+from causallib.estimation import Matching
 from causallib.survival.standardized_survival import StandardizedSurvival
 from causallib.survival.weighted_standardized_survival import WeightedStandardizedSurvival
 from causallib.survival.weighted_survival import WeightedSurvival
@@ -289,21 +290,26 @@ class TestNHEFS(unittest.TestCase):
 
         # Init various multiple models
         self.estimators = {
-            'observed_non_parametric': MarginalSurvival(),
-            'observed_parametric': MarginalSurvival(survival_model=LogisticRegression(max_iter=2000)),
-            'ipw_non_parametric': WeightedSurvival(
-                weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
-                survival_model=None),
-            'ipw_parametric': WeightedSurvival(weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
-                                               survival_model=LogisticRegression(max_iter=4000)),
-            'ipw_parametric_pipeline': WeightedSurvival(
-                weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
-                survival_model=Pipeline(
-                    [('transform', PolynomialFeatures(degree=2)), ('LR', LogisticRegression(max_iter=1000, C=2))])),
-            'standardization_non_stratified': StandardizedSurvival(survival_model=LogisticRegression(max_iter=4000),
-                                                                   stratify=False),
-            'standardization_stratified': StandardizedSurvival(survival_model=LogisticRegression(max_iter=4000),
-                                                               stratify=True),
+            # 'observed_non_parametric': MarginalSurvival(),
+            # 'observed_parametric': MarginalSurvival(survival_model=LogisticRegression(max_iter=2000)),
+            # 'ipw_non_parametric': WeightedSurvival(
+            #     weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
+            #     survival_model=None),
+            # 'ipw_parametric': WeightedSurvival(weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
+            #                                    survival_model=LogisticRegression(max_iter=4000)),
+            # 'ipw_parametric_pipeline': WeightedSurvival(
+            #     weight_model=IPW(LogisticRegression(max_iter=4000), use_stabilized=True),
+            #     survival_model=Pipeline(
+            #         [('transform', PolynomialFeatures(degree=2)), ('LR', LogisticRegression(max_iter=1000, C=2))])),
+            'matching_non_parametric': WeightedSurvival(
+                weight_model=Matching(
+                    matching_mode="treatment_to_control",
+                ),
+            ),
+            # 'standardization_non_stratified': StandardizedSurvival(survival_model=LogisticRegression(max_iter=4000),
+            #                                                        stratify=False),
+            # 'standardization_stratified': StandardizedSurvival(survival_model=LogisticRegression(max_iter=4000),
+            #                                                    stratify=True),
         }
 
     def test_nhefs(self, plot=False):
@@ -312,6 +318,7 @@ class TestNHEFS(unittest.TestCase):
                                    'ipw_non_parametric': 1,
                                    'ipw_parametric': 1,
                                    'ipw_parametric_pipeline': 1,
+                                   'matching_non_parametric': 2,  # ATC
                                    'standardization_non_stratified': 1,
                                    'standardization_stratified': 1,
                                    }


### PR DESCRIPTION
Matching can be naturally presented as a weight model (in the most basic scenario, weighting samples as zero and ones for whether they were matched or excluded).
Current implementation of `Matching` also supports this with the `matching_to_weights()` function.
However, the API did not align with `WeightEstimator`'s `compute_weights(X, a)` interface. 

This PR fixes it and realigns `Matching` to `WeightEstimator`.
This allows `Matching` to be evaluated using `evaluate` (for example, `plot_covariate_balance()`) and allows it to be plugged into other models using weight-models such as `WeightedSurvival` (which can now generate, for example, matched Kaplan-Meier curves).

This PR also includes an adjustment to the `evaluation` module to allow `Matching` to be used - moving the treatment label prediction (used for classification metrics) from the `WeightPredictions` to `PropensityPredictions`