### PR TITLE
Add **kwargs to covariate_imbalance_count_error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           # pytest tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
       
       - name: Publish to CodeClimate
-        uses: paambaati/codeclimate-action@v3.2.0
+        uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_REPORTER_ID }} 
           

--- a/causallib/metrics/weight_metrics.py
+++ b/causallib/metrics/weight_metrics.py
@@ -122,7 +122,7 @@ def covariate_balancing_error(X, a, sample_weight, agg=max, **kwargs):
 
 
 def covariate_imbalance_count_error(
-    X, a, sample_weight, threshold=0.1, fraction=True
+    X, a, sample_weight, threshold=0.1, fraction=True, **kwargs
 ) -> float:
     asmds = calculate_covariate_balance(X, a, sample_weight, metric="abs_smd")
     weighted_asmds = asmds["weighted"]

--- a/causallib/tests/test_metrics.py
+++ b/causallib/tests/test_metrics.py
@@ -298,6 +298,13 @@ class TestWeightMetrics(unittest.TestCase):
             )
             self.assertEqual(score, 1/2)
 
+        with self.subTest("Doesn't fail on unrelated kwargs"):
+            covariate_imbalance_count_error(
+                self.data["X"], self.data["a"], self.data["w"],
+                nonexistingkwarg=1,
+            )
+            self.assertTrue(True)
+
 
 class TestOutcomeMetrics(unittest.TestCase):
     def test_balanced_residuals(self):


### PR DESCRIPTION
Other error functions use **kwargs to maintain flexibility about calling API, this function was missing it.